### PR TITLE
Updating packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,39 +21,39 @@
   "author": "Mike Kornelson <mike@durbn.net>",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.24.1",
-    "babel-loader": "^6.4.1",
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.1.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
-    "chai": "^3.5.0",
-    "css-loader": "^0.28.0",
-    "enzyme": "^2.8.2",
-    "extract-text-webpack-plugin": "^2.1.0",
+    "chai": "^4.0.2",
+    "css-loader": "^0.28.4",
+    "enzyme": "^2.9.0",
+    "extract-text-webpack-plugin": "^2.1.2",
     "jsdom": "^9.12.0",
     "jsdom-global": "^2.1.1",
-    "mocha": "^3.2.0",
-    "postcss-loader": "^1.3.3",
-    "postcss-modules-values": "^1.2.2",
-    "react": "^15.5.4",
-    "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^15.5.4",
+    "mocha": "^3.4.2",
+    "postcss-loader": "^2.0.6",
+    "postcss-modules-values": "^1.3.0",
+    "react": "^15.6.1",
+    "react-addons-test-utils": "^15.6.0",
+    "react-dom": "^15.6.1",
     "react-test-renderer": "^15.6.1",
-    "semantic-ui-react": "^0.68.0",
+    "semantic-ui-react": "^0.69.0",
     "sinon": "^2.3.5",
-    "style-loader": "^0.16.1",
+    "style-loader": "^0.18.2",
     "webpack": "^2.4.1",
-    "webpack-node-externals": "^1.5.4"
+    "webpack-node-externals": "^1.6.0"
   },
   "peerDependencies": {
     "react": "^15.5.0",
-    "semantic-ui-react": "^0.68.0"
+    "semantic-ui-react": "^0.69.0"
   },
   "dependencies": {
     "debug": "^2.6.8",
     "lodash": "^4.17.4",
-    "prop-types": "^15.5.8",
-    "react-dock": "^0.2.3",
+    "prop-types": "^15.5.10",
+    "react-dock": "^0.2.4",
     "tproptypes": "^0.1.6"
   }
 }


### PR DESCRIPTION
babel-loader        ^6.4.1  →   ^7.1.0 
 chai                ^3.5.0  →   ^4.0.2 
 postcss-loader      ^1.3.3  →   ^2.0.6 
 semantic-ui-react  ^0.68.0  →  ^0.69.0 
 style-loader       ^0.16.1  →  ^0.18.2 
 prop-types                   ^15.5.8  →  ^15.5.10 
 react-dock                    ^0.2.3  →    ^0.2.4 
 babel-core                   ^6.24.1  →   ^6.25.0 
 css-loader                   ^0.28.0  →   ^0.28.4 
 enzyme                        ^2.8.2  →    ^2.9.0 
 extract-text-webpack-plugin   ^2.1.0  →    ^2.1.2 
 mocha                         ^3.2.0  →    ^3.4.2 
 postcss-modules-values        ^1.2.2  →    ^1.3.0 
 react                        ^15.5.4  →   ^15.6.1 
 react-addons-test-utils      ^15.5.1  →   ^15.6.0 
 react-dom                    ^15.5.4  →   ^15.6.1 
 webpack-node-externals        ^1.5.4  →    ^1.6.0